### PR TITLE
Fixes 'PeekViewAction' cannot be constructed because it has no accessible initializers 

### DIFF
--- a/Source/PeekView.swift
+++ b/Source/PeekView.swift
@@ -23,6 +23,11 @@ let buttonVerticalPadding = CGFloat(15)
 public struct PeekViewAction {
     var title: String
     var style: PeekViewActionStyle
+    
+    public init(title: String, style: PeekViewActionStyle){
+        self.title = title
+        self.style = style
+    }
 }
 
 @objc public class PeekView: UIView {


### PR DESCRIPTION
Fixes 'PeekViewAction' cannot be constructed because it has no accessible initializers error when using CocoaPods
